### PR TITLE
fix: nginx to accept POST and GET requests

### DIFF
--- a/RStudio/README.md
+++ b/RStudio/README.md
@@ -86,6 +86,7 @@ Since RStudio currently requires a custom domain name, please configure the same
 * The EC2 instance backing this workspace must be in the Ready state.
 * Click on the connections button and hit Connect.
 * If you're provisioning an RStudio instance with studies selected, the selected studies will show up as mounted directories in the RStudio. These study directories will contain files uploaded to the corresponding study. Any files uploaded to the study from the Service Workbench will automatically appear in the mounted study directories after a short delay.
+* Note: Connection-critical SSM parameters are created once RStudio instances are fully initialized. Allow up to a minute after an RStudio instance becomes available on Service Workbench for connections to work.
 
 **Notes**:
 * If you're provisioning an RStudio instance with studies selected, these studies will only get mounted on your instance once you click on the RStudio workspace's "Terminal" tab.

--- a/RStudio/machine-images/config/infra/files/rstudio/nginx.conf
+++ b/RStudio/machine-images/config/infra/files/rstudio/nginx.conf
@@ -25,6 +25,11 @@ http {
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;
 
+  map $request_method $temp_body {
+    POST $request_body;
+    GET $query_string;
+    default $request_method;
+  }
   map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
@@ -77,11 +82,14 @@ http {
 
     location /auth-do-sign-in {
       proxy_pass http://localhost:8787;
-      set $args $args&csrf-token=$request_id;
       proxy_set_header Cookie "csrf-token=$request_id";
       proxy_method POST;
       proxy_set_header Content-Type application/x-www-form-urlencoded;
-      proxy_set_body $query_string;
+      proxy_set_body $temp_body&csrf-token=$request_id;
+    }
+
+    location /auth-sign-in {
+      return 403;
     }
 
   }

--- a/RStudio/machine-images/config/infra/files/rstudio/nginx.conf
+++ b/RStudio/machine-images/config/infra/files/rstudio/nginx.conf
@@ -25,10 +25,9 @@ http {
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;
 
-  map $request_method $temp_body {
+  map $request_method $proxy_body {
     POST $request_body;
     GET $query_string;
-    default $request_method;
   }
   map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -85,7 +84,7 @@ http {
       proxy_set_header Cookie "csrf-token=$request_id";
       proxy_method POST;
       proxy_set_header Content-Type application/x-www-form-urlencoded;
-      proxy_set_body $temp_body&csrf-token=$request_id;
+      proxy_set_body $proxy_body&csrf-token=$request_id;
     }
 
     location /auth-sign-in {


### PR DESCRIPTION
Adding logic to NGINX to accept both POST and GET requests.
Adding a note in Readme for allowing SSM params to be generated for connection.