### PR TITLE
fix: flakiness on set-password trigger

### DIFF
--- a/RStudio/machine-images/config/infra/provisioners/provision-rstudio.sh
+++ b/RStudio/machine-images/config/infra/provisioners/provision-rstudio.sh
@@ -62,7 +62,7 @@ sudo mv "/tmp/rstudio/set-password" "/usr/local/bin/"
 sudo chown root: "/usr/local/bin/set-password"
 sudo chmod 775 "/usr/local/bin/set-password"
 sudo crontab -l 2>/dev/null > "/tmp/crontab"
-sudo sh "/usr/loca/bin/set-password"
+sudo sh "/usr/local/bin/set-password"
 echo '@reboot /usr/local/bin/set-password 2>&1 >> /var/log/set-password.log' >> "/tmp/crontab"
 sudo crontab "/tmp/crontab"
 

--- a/RStudio/machine-images/config/infra/provisioners/provision-rstudio.sh
+++ b/RStudio/machine-images/config/infra/provisioners/provision-rstudio.sh
@@ -62,6 +62,7 @@ sudo mv "/tmp/rstudio/set-password" "/usr/local/bin/"
 sudo chown root: "/usr/local/bin/set-password"
 sudo chmod 775 "/usr/local/bin/set-password"
 sudo crontab -l 2>/dev/null > "/tmp/crontab"
+sudo sh "/usr/loca/bin/set-password"
 echo '@reboot /usr/local/bin/set-password 2>&1 >> /var/log/set-password.log' >> "/tmp/crontab"
 sudo crontab "/tmp/crontab"
 


### PR DESCRIPTION
Issue:
There was some flakiness observed inconsistently on RStudio instances where the Connect button on Service Workbench did not generate a connection URL with a `ParameterNotFound` exception. When this occurs, it was noticed that some connection-critical SSM parameters were not generated in the hosting account. The `set-password` script is responsible for creating these parameters on EC2 boot time.

Workaround:
Stopping and starting the RStudio instance via SWB.

Fix in PR:
Triggering the `set-password` script once while configuring it with crontab.