### PR TITLE
fix: rstudio create script bugs

### DIFF
--- a/RStudio/machine-images/config/infra/configuration.json
+++ b/RStudio/machine-images/config/infra/configuration.json
@@ -5,5 +5,6 @@
     "vpcId": "",
     "subnetId": "",
     "amiName": "",
-    "awsProfile": ""
+    "awsProfile": "",
+    "stageName": ""
 }


### PR DESCRIPTION
There are a few bugs I found while using the python create rstudio script:

1. If you have multiple stage files (or just any files that end with `.yml` or `.yaml`), the script loops through all of them and arbitrarily uses the last one as the `fileName` later on. If your stage file is not the last one alphabetically, this will cause issues.
2. The script assumes the user will be using the default AWS profile even though the configuration file and stage file asks for the AWS Profile name and region. We should use the values from the file to account for the case that the user is not using the default profile.
3. The check on stack status is broken. The second `if` statement in `describeStack` would always evaluated to true with how the conditions were listed. In the weird case that the stack is not yet in `create_complete` state when that method is called, the second if statement would trigger the deleting of that stack. If the stack was still in `create_in_progress`, this would try to delete the stack before it has finished, which should fail.

After changing the script, I tested that:
- packer still works with additional `stageName` parameter in `configuration.json`
- script found the right stage file even if it is not the first in the directory tree
- script found the right stage file even if it is not the last in the directory tree
- script successfully failed when there is not stage file that matches the `stageName` parameter provided in the `configuration.json` file
- script creates resources in the proper AWS account and region with setting the session profile name and region from the `configuration.json` file
- (before changes, I tested that) the second `describeStack` `if` statement always did evaluate to true
- the new second `if` in `describeStack` does only evaluate to true if the status is one of the states that is supposed to trigger the delete stack method.