### PR TITLE
Fix: SSM parameter update fail on EC2 provision

### DIFF
--- a/RStudio/machine-images/config/infra/files/rstudio/set-password
+++ b/RStudio/machine-images/config/infra/files/rstudio/set-password
@@ -9,6 +9,7 @@ password=$(echo -n "${instance_id}${secret}" | sha256sum | awk '{print $1}')
 echo "rstudio-user:$password" | /usr/sbin/chpasswd
 echo "Set rstudio-user password"
 
+sleep 10
 public_key=$(curl http://localhost:8787/auth-public-key)
 instance_region=$(curl -s "http://169.254.169.254/latest/meta-data/placement/region")
 aws ssm put-parameter --name "/rstudio/publickey/sc-environments/ec2-instance/${instance_id}" --value $public_key --region $instance_region --type SecureString --overwrite 


### PR DESCRIPTION
Fix: SSM parameter update fail on EC2 provision. Adding a sleep for 10s so the SSM update will not fail